### PR TITLE
👷 Introduce OneOf<Success,Error> pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,94 @@ just run-lsp linux-x64
 just run-lsp-named-pipes linux-x64
 ```
 
+## Git Workflow
+
+### Feature Branch Development
+
+All development should be done on feature branches rather than directly on main. Follow this workflow:
+
+**1. Create Feature Branch**
+```bash
+# Create and switch to a new feature branch
+git checkout -b features/name-of-the-feature
+
+# Or using git switch (newer command)
+git switch -c features/name-of-the-feature
+```
+
+**2. Development Process**
+- Make your changes on the feature branch
+- Commit changes with descriptive messages
+- Push the branch to GitHub:
+```bash
+git push -u origin features/name-of-the-feature
+```
+
+**3. Create Pull Request**
+```bash
+# Create PR using GitHub CLI
+gh pr create --title "Feature: Description of the feature" --body "Detailed description of changes"
+
+# Or create PR with more detailed body
+gh pr create --title "Feature: Add new MCP tool" --body "$(cat <<'EOF'
+## Summary
+- Added new MCP tool for workspace operations
+- Implemented comprehensive error handling
+- Added unit tests for new functionality
+
+## Test plan
+- [ ] Run `dotnet build` to ensure compilation
+- [ ] Run `dotnet test` to verify all tests pass
+- [ ] Test MCP tool functionality manually
+- [ ] Verify LSP integration works correctly
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+**4. Review and Merge**
+- Review the PR on GitHub
+- Address any feedback or requested changes
+- Once approved, merge the PR:
+```bash
+# Merge via GitHub CLI (creates merge commit)
+gh pr merge --merge
+
+# Or merge via GitHub web interface
+```
+
+**5. Cleanup**
+```bash
+# After PR is merged, clean up local branch
+git switch main
+git pull origin main
+git branch -d features/name-of-the-feature
+```
+
+### Branch Naming Convention
+
+Use descriptive branch names with the `features/` prefix:
+- `features/add-completion-tool`
+- `features/improve-error-handling`
+- `features/refactor-application-service`
+- `features/update-documentation`
+
+### Commit Message Guidelines
+
+- Use imperative mood ("Add feature" not "Added feature")
+- Keep first line under 50 characters
+- Include more detailed description if needed
+- Reference issues when applicable
+
+### Pull Request Guidelines
+
+- Include a clear title and description
+- List what was changed and why
+- Include test plan or verification steps
+- Use the 🤖 Generated with [Claude Code](https://claude.ai/code) footer
+- Link to relevant issues
+
 ## Architecture
 
 The project is structured as a multi-layered architecture:

--- a/src/LspUse.Application/ApplicationService.cs
+++ b/src/LspUse.Application/ApplicationService.cs
@@ -6,6 +6,7 @@ using LspUse.LanguageServerClient.Handlers;
 using LspUse.LanguageServerClient.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OneOf;
 using StreamJsonRpc;
 
 namespace LspUse.Application;
@@ -183,104 +184,168 @@ public class ApplicationService : IApplicationService
         _logger.LogInformation("Successully loaded workspace");
     }
 
-    public async Task<FindReferencesResult> FindReferencesAsync(FindReferencesRequest request,
+    public async Task<OneOf<FindReferencesSuccess, ApplicationServiceError>> FindReferencesAsync(FindReferencesRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         _logger.LogInformation("[{Name}] {@Request}", nameof(FindReferencesAsync), request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        try
         {
-            var references = await LanguageServer.ReferencesAsync(new DocumentClientRequest
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                Document = fileUri,
-                Position = request.Position.ToZeroBased()
+                var references = await LanguageServer.ReferencesAsync(new DocumentClientRequest
+                {
+                    Document = fileUri,
+                    Position = request.Position.ToZeroBased()
+                }, cancellationToken);
+
+                var locations = references.Select(x => x.ToSymbolLocation());
+                var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+
+                return new FindReferencesSuccess
+                {
+                    Value = enrichedLocations
+                };
             }, cancellationToken);
 
-            var locations = references.Select(x => x.ToSymbolLocation());
-            var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[FindReferences] Error occurred while processing find references request for {FilePath}:{Line}:{Character}",
+                request.FilePath, request.Position.Line, request.Position.Character);
 
-            return new FindReferencesResult
+            return new ApplicationServiceError
             {
-                Value = enrichedLocations
+                Message = "Failed to find references",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
-    public async Task<GoToResult> GoToDefinitionAsync(GoToRequest request,
+    public async Task<OneOf<GoToSuccess, ApplicationServiceError>> GoToDefinitionAsync(GoToRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         _logger.LogInformation("[{Name}] {@Request}", nameof(GoToDefinitionAsync), request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        try
         {
-            var definitions = await LanguageServer.DefinitionAsync(new DocumentClientRequest
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                Document = fileUri,
-                Position = request.Position.ToZeroBased()
+                var definitions = await LanguageServer.DefinitionAsync(new DocumentClientRequest
+                {
+                    Document = fileUri,
+                    Position = request.Position.ToZeroBased()
+                }, cancellationToken);
+
+                var locations = definitions.Select(x => x.ToSymbolLocation());
+                var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+
+                return new GoToSuccess
+                {
+                    Locations = enrichedLocations
+                };
             }, cancellationToken);
 
-            var locations = definitions.Select(x => x.ToSymbolLocation());
-            var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[GoToDefinition] Error occurred while processing go to definition request for {FilePath}:{Line}:{Character}",
+                request.FilePath, request.Position.Line, request.Position.Character);
 
-            return new GoToResult
+            return new ApplicationServiceError
             {
-                Locations = enrichedLocations
+                Message = "Failed to go to definition",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
-    public async Task<GoToResult> GoToTypeDefinitionAsync(GoToRequest request,
+    public async Task<OneOf<GoToSuccess, ApplicationServiceError>> GoToTypeDefinitionAsync(GoToRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         _logger.LogInformation("[{Name}] {@Request}", nameof(GoToTypeDefinitionAsync), request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        try
         {
-            var typeDefinitions = await LanguageServer.TypeDefinitionAsync(new DocumentClientRequest
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                Document = fileUri,
-                Position = request.Position.ToZeroBased()
+                var typeDefinitions = await LanguageServer.TypeDefinitionAsync(new DocumentClientRequest
+                {
+                    Document = fileUri,
+                    Position = request.Position.ToZeroBased()
+                }, cancellationToken);
+
+                var locations = typeDefinitions.Select(x => x.ToSymbolLocation());
+                var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+
+                return new GoToSuccess
+                {
+                    Locations = enrichedLocations
+                };
             }, cancellationToken);
 
-            var locations = typeDefinitions.Select(x => x.ToSymbolLocation());
-            var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[GoToTypeDefinition] Error occurred while processing go to type definition request for {FilePath}:{Line}:{Character}",
+                request.FilePath, request.Position.Line, request.Position.Character);
 
-            return new GoToResult
+            return new ApplicationServiceError
             {
-                Locations = enrichedLocations
+                Message = "Failed to go to type definition",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
-    public async Task<GoToResult> GoToImplementationAsync(GoToRequest request,
+    public async Task<OneOf<GoToSuccess, ApplicationServiceError>> GoToImplementationAsync(GoToRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         _logger.LogInformation("[{Name}] {@Request}", nameof(GoToImplementationAsync), request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        try
         {
-            var implementations = await LanguageServer.ImplementationAsync(new DocumentClientRequest
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                Document = fileUri,
-                Position = request.Position.ToZeroBased()
+                var implementations = await LanguageServer.ImplementationAsync(new DocumentClientRequest
+                {
+                    Document = fileUri,
+                    Position = request.Position.ToZeroBased()
+                }, cancellationToken);
+
+                var locations = implementations.Select(x => x.ToSymbolLocation());
+                var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+
+                return new GoToSuccess
+                {
+                    Locations = enrichedLocations
+                };
             }, cancellationToken);
 
-            var locations = implementations.Select(x => x.ToSymbolLocation());
-            var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[GoToImplementation] Error occurred while processing go to implementation request for {FilePath}:{Line}:{Character}",
+                request.FilePath, request.Position.Line, request.Position.Character);
 
-            return new GoToResult
+            return new ApplicationServiceError
             {
-                Locations = enrichedLocations
+                Message = "Failed to go to implementation",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
     private static string ExtractLanguageFromExt(string path) =>
@@ -293,7 +358,7 @@ public class ApplicationService : IApplicationService
             _ => "plaintext"
         };
 
-    public async Task<CompletionResult> CompletionAsync(CompletionRequest request,
+    public async Task<OneOf<CompletionSuccess, ApplicationServiceError>> CompletionAsync(CompletionRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -304,25 +369,41 @@ public class ApplicationService : IApplicationService
         _logger.LogTrace("[Process] Pid:{Pid} Exited:{HasExited}", _process?.Id,
             _process?.HasExited);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        try
         {
-            var completionList = await LanguageServer.CompletionAsync(new DocumentClientRequest
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                Document = fileUri,
-                Position = request.Position.ToZeroBased()
+                var completionList = await LanguageServer.CompletionAsync(new DocumentClientRequest
+                {
+                    Document = fileUri,
+                    Position = request.Position.ToZeroBased()
+                }, cancellationToken);
+
+                var count = completionList?.Items?.Length ?? 0;
+
+                return new CompletionSuccess
+                {
+                    Items = count > 0 ? completionList?.Items ?? [] : [],
+                    IsIncomplete = completionList?.IsIncomplete ?? false
+                };
             }, cancellationToken);
 
-            var count = completionList?.Items?.Length ?? 0;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Completion] Error occurred while processing completion request for {FilePath}:{Line}:{Character}",
+                request.FilePath, request.Position.Line, request.Position.Character);
 
-            return new CompletionResult
+            return new ApplicationServiceError
             {
-                Items = count > 0 ? completionList?.Items ?? [] : [],
-                IsIncomplete = completionList?.IsIncomplete ?? false
+                Message = "Failed to get completion suggestions",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
-    public async Task<HoverResult> HoverAsync(HoverRequest request,
+    public async Task<OneOf<HoverSuccess, ApplicationServiceError>> HoverAsync(HoverRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -333,73 +414,101 @@ public class ApplicationService : IApplicationService
         _logger.LogTrace("[Process] Pid:{Pid} Exited:{HasExited}", _process?.Id,
             _process?.HasExited);
 
-        EnsureFileExists(request.FilePath, out var absoluteFileUri);
-
-        await OpenFileOnLspAsync(absoluteFileUri, cancellationToken);
-
-        var hover = await LanguageServer.HoverAsync(new DocumentClientRequest
+        try
         {
-            Document = absoluteFileUri,
-            Position = request.Position.ToZeroBased()
-        }, cancellationToken);
+            EnsureFileExists(request.FilePath, out var absoluteFileUri);
 
-        _logger.LogInformation("[Hover] Content:{Content}", hover?.Contents?.Value);
+            await OpenFileOnLspAsync(absoluteFileUri, cancellationToken);
 
-        await CloseFileOnLspAsync(absoluteFileUri, cancellationToken);
+            var hover = await LanguageServer.HoverAsync(new DocumentClientRequest
+            {
+                Document = absoluteFileUri,
+                Position = request.Position.ToZeroBased()
+            }, cancellationToken);
 
-        return new HoverResult
+            _logger.LogInformation("[Hover] Content:{Content}", hover?.Contents?.Value);
+
+            await CloseFileOnLspAsync(absoluteFileUri, cancellationToken);
+
+            return new HoverSuccess
+            {
+                Value = hover?.Contents?.Value ?? string.Empty
+            };
+        }
+        catch (Exception ex)
         {
-            Value = hover?.Contents?.Value ?? string.Empty
-        };
+            _logger.LogError(ex, "[Hover] Error occurred while processing hover request for {FilePath}:{Line}:{Character}",
+                request.FilePath, request.Position.Line, request.Position.Character);
+
+            return new ApplicationServiceError
+            {
+                Message = "Failed to get hover information",
+                Exception = ex
+            };
+        }
     }
 
-    public async Task<SearchSymbolResponse> SearchSymbolAsync(SearchSymbolRequest request,
+    public async Task<OneOf<SearchSymbolSuccess, ApplicationServiceError>> SearchSymbolAsync(SearchSymbolRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var matchingSymbols = await LanguageServer.WorkspaceSymbolAsync(new WorkspaceSymbolParams
+        try
         {
-            Query = request.Query
-        }, cancellationToken);
-
-        var documentSymbols = matchingSymbols.Select(s => new DocumentSymbol
-        {
-            Name = s.Name ?? string.Empty,
-            Kind = s.Kind?.ToString() ?? "Unknown",
-            ContainerName = s.ContainerName,
-            Location = s.Location?.ToSymbolLocation()
-        })
-            .ToList();
-
-        // Extract locations, enrich them, and create a lookup
-        var locations = documentSymbols.Where(s => s.Location != null).Select(s => s.Location!);
-        var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
-        var enrichedLookup = enrichedLocations.ToLookup(loc =>
-            $"{loc.FilePath}:{loc.StartLine}:{loc.StartCharacter}:{loc.EndLine}:{loc.EndCharacter}");
-
-        // Update document symbols with enriched locations
-        var enrichedSymbols = documentSymbols.Select(symbol =>
-        {
-            if (symbol.Location == null) return symbol;
-
-            var key =
-                $"{symbol.Location.FilePath}:{symbol.Location.StartLine}:{symbol.Location.StartCharacter}:{symbol.Location.EndLine}:{symbol.Location.EndCharacter}";
-            var enrichedLocation = enrichedLookup[key].FirstOrDefault();
-
-            return symbol with
+            var matchingSymbols = await LanguageServer.WorkspaceSymbolAsync(new WorkspaceSymbolParams
             {
-                Location = enrichedLocation ?? symbol.Location
-            };
-        });
+                Query = request.Query
+            }, cancellationToken);
 
-        return new SearchSymbolResponse
+            var documentSymbols = matchingSymbols.Select(s => new DocumentSymbol
+            {
+                Name = s.Name ?? string.Empty,
+                Kind = s.Kind?.ToString() ?? "Unknown",
+                ContainerName = s.ContainerName,
+                Location = s.Location?.ToSymbolLocation()
+            })
+                .ToList();
+
+            // Extract locations, enrich them, and create a lookup
+            var locations = documentSymbols.Where(s => s.Location != null).Select(s => s.Location!);
+            var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+            var enrichedLookup = enrichedLocations.ToLookup(loc =>
+                $"{loc.FilePath}:{loc.StartLine}:{loc.StartCharacter}:{loc.EndLine}:{loc.EndCharacter}");
+
+            // Update document symbols with enriched locations
+            var enrichedSymbols = documentSymbols.Select(symbol =>
+            {
+                if (symbol.Location == null) return symbol;
+
+                var key =
+                    $"{symbol.Location.FilePath}:{symbol.Location.StartLine}:{symbol.Location.StartCharacter}:{symbol.Location.EndLine}:{symbol.Location.EndCharacter}";
+                var enrichedLocation = enrichedLookup[key].FirstOrDefault();
+
+                return symbol with
+                {
+                    Location = enrichedLocation ?? symbol.Location
+                };
+            });
+
+            return new SearchSymbolSuccess
+            {
+                Value = enrichedSymbols
+            };
+        }
+        catch (Exception ex)
         {
-            Value = enrichedSymbols
-        };
+            _logger.LogError(ex, "[SearchSymbol] Error occurred while processing search symbol request for query: {Query}",
+                request.Query);
+
+            return new ApplicationServiceError
+            {
+                Message = "Failed to search symbols",
+                Exception = ex
+            };
+        }
     }
 
-    public async Task<WindowLog> GetWindowLogMessagesAsync(WindowLogRequest request,
+    public async Task<OneOf<WindowLog, ApplicationServiceError>> GetWindowLogMessagesAsync(WindowLogRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -409,26 +518,39 @@ public class ApplicationService : IApplicationService
         _logger.LogTrace("[Process] Pid:{Pid} Exited:{HasExited}", _process?.Id,
             _process?.HasExited);
 
-        await Task.CompletedTask;
-
-        var windowNotificationHandler = _lspNotificationHandlers.OfType<WindowNotificationHandler>()
-            .FirstOrDefault();
-
-        if (windowNotificationHandler == null)
+        try
         {
-            _logger.LogWarning("[GetWindowLogMessages] WindowNotificationHandler not found");
+            await Task.CompletedTask;
 
-            return new WindowLog([]);
+            var windowNotificationHandler = _lspNotificationHandlers.OfType<WindowNotificationHandler>()
+                .FirstOrDefault();
+
+            if (windowNotificationHandler == null)
+            {
+                _logger.LogWarning("[GetWindowLogMessages] WindowNotificationHandler not found");
+
+                return new WindowLog([]);
+            }
+
+            var logMessages = windowNotificationHandler.LogMessages
+                .Select(x => new WindowLogMessage(x.Message ?? string.Empty, x.MessageType))
+                .ToList();
+
+            _logger.LogInformation("[GetWindowLogMessages] Retrieved {Count} log messages",
+                logMessages.Count);
+
+            return new WindowLog(logMessages);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[GetWindowLogMessages] Error occurred while retrieving window log messages");
 
-        var logMessages = windowNotificationHandler.LogMessages
-            .Select(x => new WindowLogMessage(x.Message ?? string.Empty, x.MessageType))
-            .ToList();
-
-        _logger.LogInformation("[GetWindowLogMessages] Retrieved {Count} log messages",
-            logMessages.Count);
-
-        return new WindowLog(logMessages);
+            return new ApplicationServiceError
+            {
+                Message = "Failed to get window log messages",
+                Exception = ex
+            };
+        }
     }
 
     // TODO: this has many concerns, to sort
@@ -497,228 +619,280 @@ public class ApplicationService : IApplicationService
         }
     }
 
-    public async Task<GetSymbolsResult> GetDocumentSymbolsAsync(GetSymbolsRequest request,
+    public async Task<OneOf<GetSymbolsSuccess, ApplicationServiceError>> GetDocumentSymbolsAsync(GetSymbolsRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        try
         {
-            var documentSymbols = await LanguageServer.DocumentSymbolAsync(new DocumentSymbolParams
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                TextDocument = fileUri.ToDocumentIdentifier()
+                var documentSymbols = await LanguageServer.DocumentSymbolAsync(new DocumentSymbolParams
+                {
+                    TextDocument = fileUri.ToDocumentIdentifier()
+                }, cancellationToken);
+
+                var symbols = documentSymbols?.Select(x => new DocumentSymbol
+                {
+                    Name = x.Name,
+                    ContainerName = x.ContainerName,
+                    Kind = x.Kind.ToString(),
+                    Location = x.Location?.ToSymbolLocation()
+                })
+                    .ToList() ?? [];
+
+                // Extract locations, enrich them, and create a lookup
+                var locations = symbols.Where(s => s.Location != null).Select(s => s.Location!);
+                var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
+                var enrichedLookup = enrichedLocations.ToLookup(loc =>
+                    $"{loc.FilePath}:{loc.StartLine}:{loc.StartCharacter}:{loc.EndLine}:{loc.EndCharacter}");
+
+                // Update document symbols with enriched locations
+                var enrichedSymbols = symbols.Select(symbol =>
+                {
+                    if (symbol.Location == null) return symbol;
+
+                    var key =
+                        $"{symbol.Location.FilePath}:{symbol.Location.StartLine}:{symbol.Location.StartCharacter}:{symbol.Location.EndLine}:{symbol.Location.EndCharacter}";
+                    var enrichedLocation = enrichedLookup[key].FirstOrDefault();
+
+                    return symbol with
+                    {
+                        Location = enrichedLocation ?? symbol.Location
+                    };
+                });
+
+                return new GetSymbolsSuccess
+                {
+                    Symbols = enrichedSymbols
+                };
             }, cancellationToken);
 
-            var symbols = documentSymbols?.Select(x => new DocumentSymbol
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[GetDocumentSymbols] Error occurred while processing get document symbols request for {FilePath}",
+                request.FilePath);
+
+            return new ApplicationServiceError
             {
-                Name = x.Name,
-                ContainerName = x.ContainerName,
-                Kind = x.Kind.ToString(),
-                Location = x.Location?.ToSymbolLocation()
-            })
-                .ToList() ?? [];
-
-            // Extract locations, enrich them, and create a lookup
-            var locations = symbols.Where(s => s.Location != null).Select(s => s.Location!);
-            var enrichedLocations = await locations.EnrichWithTextAsync(cancellationToken);
-            var enrichedLookup = enrichedLocations.ToLookup(loc =>
-                $"{loc.FilePath}:{loc.StartLine}:{loc.StartCharacter}:{loc.EndLine}:{loc.EndCharacter}");
-
-            // Update document symbols with enriched locations
-            var enrichedSymbols = symbols.Select(symbol =>
-            {
-                if (symbol.Location == null) return symbol;
-
-                var key =
-                    $"{symbol.Location.FilePath}:{symbol.Location.StartLine}:{symbol.Location.StartCharacter}:{symbol.Location.EndLine}:{symbol.Location.EndCharacter}";
-                var enrichedLocation = enrichedLookup[key].FirstOrDefault();
-
-                return symbol with
-                {
-                    Location = enrichedLocation ?? symbol.Location
-                };
-            });
-
-            return new GetSymbolsResult
-            {
-                Symbols = enrichedSymbols
+                Message = "Failed to get document symbols",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
-    public async Task<IEnumerable<DocumentDiagnostic>> GetDocumentDiagnosticsAsync(
+    public async Task<OneOf<IEnumerable<DocumentDiagnostic>, ApplicationServiceError>> GetDocumentDiagnosticsAsync(
         DocumentDiagnosticsRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async fileUri =>
+        _logger.LogInformation("[{Name}] {@Request}", nameof(GetDocumentDiagnosticsAsync), request);
+
+        try
         {
-            var clientCapabilityRegistrationHandler = _lspNotificationHandlers
-                .OfType<ClientCapabilityRegistrationHandler>()
-                .FirstOrDefault();
-
-            if (clientCapabilityRegistrationHandler == null)
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async fileUri =>
             {
-                _logger.LogWarning(
-                    "[GetDocumentDiagnosticsAsync] ClientCapabilityRegistrationHandler not found");
+                var clientCapabilityRegistrationHandler = _lspNotificationHandlers
+                    .OfType<ClientCapabilityRegistrationHandler>()
+                    .FirstOrDefault();
 
-                return [];
-            }
-
-            // Check if registrations are completed or if we have any registrations
-            if (!clientCapabilityRegistrationHandler.RegistrationCompleted.IsCompleted &&
-                !clientCapabilityRegistrationHandler.Registrations.Any())
-            {
-                _logger.LogWarning(
-                    "[GetDocumentDiagnosticsAsync] No diagnostic registrations available");
-
-                return [];
-            }
-
-            var diagnostics = new List<Diagnostic>();
-
-            // Get all diagnostic registrations
-            var registrations = clientCapabilityRegistrationHandler.Registrations.ToArray();
-            var textDocumentDiagnosticRegistrations = registrations
-                .Where(r => r.Method == "textDocument/diagnostic")
-                .ToArray();
-
-            foreach (var registration in textDocumentDiagnosticRegistrations)
-            {
-                var identifier = registration.RegisterOptions?.Identifier;
-
-                if (string.IsNullOrEmpty(identifier))
-                    continue;
-
-                _logger.LogDebug(
-                    "[GetDocumentDiagnosticsAsync] Fetching diagnostics for identifier: {Identifier}",
-                    identifier);
-
-                try
+                if (clientCapabilityRegistrationHandler == null)
                 {
-                    var response = await LanguageServer.DiagnosticAsync(
-                        new TextDocumentDiagnosticParams
-                        {
-                            TextDocument = fileUri.ToDocumentIdentifier(),
-                            Identifier = identifier
-                        }, cancellationToken);
+                    _logger.LogWarning(
+                        "[GetDocumentDiagnosticsAsync] ClientCapabilityRegistrationHandler not found");
 
-                    if (response?.Items != null) diagnostics.AddRange(response.Items);
+                    return [];
                 }
-                catch (Exception ex)
+
+                // Check if registrations are completed or if we have any registrations
+                if (!clientCapabilityRegistrationHandler.RegistrationCompleted.IsCompleted &&
+                    !clientCapabilityRegistrationHandler.Registrations.Any())
                 {
-                    _logger.LogWarning(ex,
-                        "[GetDocumentDiagnosticsAsync] Failed to fetch diagnostics for identifier: {Identifier}",
+                    _logger.LogWarning(
+                        "[GetDocumentDiagnosticsAsync] No diagnostic registrations available");
+
+                    return [];
+                }
+
+                var diagnostics = new List<Diagnostic>();
+
+                // Get all diagnostic registrations
+                var registrations = clientCapabilityRegistrationHandler.Registrations.ToArray();
+                var textDocumentDiagnosticRegistrations = registrations
+                    .Where(r => r.Method == "textDocument/diagnostic")
+                    .ToArray();
+
+                foreach (var registration in textDocumentDiagnosticRegistrations)
+                {
+                    var identifier = registration.RegisterOptions?.Identifier;
+
+                    if (string.IsNullOrEmpty(identifier))
+                        continue;
+
+                    _logger.LogDebug(
+                        "[GetDocumentDiagnosticsAsync] Fetching diagnostics for identifier: {Identifier}",
                         identifier);
+
+                    try
+                    {
+                        var response = await LanguageServer.DiagnosticAsync(
+                            new TextDocumentDiagnosticParams
+                            {
+                                TextDocument = fileUri.ToDocumentIdentifier(),
+                                Identifier = identifier
+                            }, cancellationToken);
+
+                        if (response?.Items != null) diagnostics.AddRange(response.Items);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "[GetDocumentDiagnosticsAsync] Failed to fetch diagnostics for identifier: {Identifier}",
+                            identifier);
+                    }
                 }
-            }
 
-            // Convert to our model format
-            var documentDiagnostics = new List<DocumentDiagnostic>();
+                // Convert to our model format
+                var documentDiagnostics = new List<DocumentDiagnostic>();
 
-            foreach (var diagnostic in diagnostics)
+                foreach (var diagnostic in diagnostics)
+                {
+                    if (diagnostic.Range?.Start == null || diagnostic.Range?.End == null)
+                        continue;
+
+                    var severity = diagnostic.Severity switch
+                    {
+                        DiagnosticSeverity.Error => "Error",
+                        DiagnosticSeverity.Warning => "Warning",
+                        DiagnosticSeverity.Information => "Information",
+                        DiagnosticSeverity.Hint => "Hint",
+                        _ => "Unknown"
+                    };
+
+                    documentDiagnostics.Add(new DocumentDiagnostic
+                    {
+                        Severity = severity,
+                        StartLine = (uint)diagnostic.Range.Start.Line,
+                        StartCharacter = (uint)diagnostic.Range.Start.Character,
+                        EndLine = (uint)diagnostic.Range.End.Line,
+                        EndCharacter = (uint)diagnostic.Range.End.Character,
+                        Message = diagnostic.Message ?? string.Empty,
+                        Code = diagnostic.Code,
+                        CodeDescription = diagnostic.CodeDescription?.Href
+                    });
+                }
+
+                // Enrich diagnostics with text content
+                var enrichedDiagnostics =
+                    await documentDiagnostics.EnrichWithTextAsync(request.FilePath, cancellationToken);
+
+                // Sort by severity (Error → Warning → Information → Hint) then by line number
+                return enrichedDiagnostics.OrderBy(d => d.SeverityOrder)
+                    .ThenBy(d => d.StartLine)
+                    .ThenBy(d => d.StartCharacter)
+                    .ToArray();
+            }, cancellationToken);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[GetDocumentDiagnosticsAsync] Error occurred while processing get document diagnostics request for {FilePath}",
+                request.FilePath);
+
+            return new ApplicationServiceError
             {
-                if (diagnostic.Range?.Start == null || diagnostic.Range?.End == null)
-                    continue;
-
-                var severity = diagnostic.Severity switch
-                {
-                    DiagnosticSeverity.Error => "Error",
-                    DiagnosticSeverity.Warning => "Warning",
-                    DiagnosticSeverity.Information => "Information",
-                    DiagnosticSeverity.Hint => "Hint",
-                    _ => "Unknown"
-                };
-
-                documentDiagnostics.Add(new DocumentDiagnostic
-                {
-                    Severity = severity,
-                    StartLine = (uint)diagnostic.Range.Start.Line,
-                    StartCharacter = (uint)diagnostic.Range.Start.Character,
-                    EndLine = (uint)diagnostic.Range.End.Line,
-                    EndCharacter = (uint)diagnostic.Range.End.Character,
-                    Message = diagnostic.Message ?? string.Empty,
-                    Code = diagnostic.Code,
-                    CodeDescription = diagnostic.CodeDescription?.Href
-                });
-            }
-
-            // Enrich diagnostics with text content
-            var enrichedDiagnostics =
-                await documentDiagnostics.EnrichWithTextAsync(request.FilePath, cancellationToken);
-
-            // Sort by severity (Error → Warning → Information → Hint) then by line number
-            return enrichedDiagnostics.OrderBy(d => d.SeverityOrder)
-                .ThenBy(d => d.StartLine)
-                .ThenBy(d => d.StartCharacter)
-                .ToArray();
-        }, cancellationToken);
+                Message = "Failed to get document diagnostics",
+                Exception = ex
+            };
+        }
     }
 
-    public async Task<RenameSymbolResult> RenameSymbolAsync(RenameSymbolRequest request,
+    public async Task<OneOf<RenameSymbolSuccess, ApplicationServiceError>> RenameSymbolAsync(RenameSymbolRequest request,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        return await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
+        _logger.LogInformation("[{Name}] {@Request}", nameof(RenameSymbolAsync), request);
+
+        try
         {
-            var workspaceEdit = await LanguageServer.RenameAsync(new RenameParams
+            var result = await ExecuteWithFileLifecycleAsync(request.FilePath, async (fileUri) =>
             {
-                TextDocument = fileUri.ToDocumentIdentifier(),
-                Position = request.Position.ToZeroBased(),
-                NewName = request.NewName
+                var workspaceEdit = await LanguageServer.RenameAsync(new RenameParams
+                {
+                    TextDocument = fileUri.ToDocumentIdentifier(),
+                    Position = request.Position.ToZeroBased(),
+                    NewName = request.NewName
+                }, cancellationToken);
+
+                if (workspaceEdit == null)
+                {
+                    _logger.LogWarning("LSP returned null workspace edit for rename operation");
+
+                    return new RenameSymbolSuccess
+                    {
+                        Success = false,
+                        Errors = ["LSP returned no changes for rename operation"],
+                        ChangedFiles = [],
+                        TotalEditsApplied = 0,
+                        TotalFilesChanged = 0,
+                        TotalLinesChanged = 0
+                    };
+                }
+
+                // TODO: Inject from DI
+                var applicator =
+                    new WorkspaceEditApplicator(_loggerFactory.CreateLogger<WorkspaceEditApplicator>());
+                var applicatorResult = await applicator.ApplyAsync(workspaceEdit, cancellationToken);
+
+                if (applicatorResult.HasErrors)
+                {
+                    _logger.LogError("Failed to apply rename changes: {Errors}",
+                        string.Join(", ", applicatorResult.Errors));
+
+                    return new RenameSymbolSuccess
+                    {
+                        Success = false,
+                        Errors = applicatorResult.Errors,
+                        ChangedFiles = [],
+                        TotalEditsApplied = 0,
+                        TotalFilesChanged = 0,
+                        TotalLinesChanged = 0
+                    };
+                }
+
+                _logger.LogInformation(
+                    "Successfully renamed symbol: {TotalFilesChanged} files, {TotalEditsApplied} edits, {TotalLinesChanged} lines",
+                    applicatorResult.TotalFilesChanged, applicatorResult.TotalEditsApplied, applicatorResult.TotalLinesChanged);
+
+                return new RenameSymbolSuccess
+                {
+                    Success = true,
+                    Errors = [],
+                    ChangedFiles = applicatorResult.FilesChanged.Select(r => r.FilePath),
+                    TotalFilesChanged = applicatorResult.TotalFilesChanged,
+                    TotalEditsApplied = applicatorResult.TotalEditsApplied,
+                    TotalLinesChanged = applicatorResult.TotalLinesChanged
+                };
             }, cancellationToken);
 
-            if (workspaceEdit == null)
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[RenameSymbol] Error occurred while processing rename symbol request for {FilePath}:{Line}:{Character} -> {NewName}",
+                request.FilePath, request.Position.Line, request.Position.Character, request.NewName);
+
+            return new ApplicationServiceError
             {
-                _logger.LogWarning("LSP returned null workspace edit for rename operation");
-
-                return new RenameSymbolResult
-                {
-                    Success = false,
-                    Errors = ["LSP returned no changes for rename operation"],
-                    ChangedFiles = [],
-                    TotalEditsApplied = 0,
-                    TotalFilesChanged = 0,
-                    TotalLinesChanged = 0
-                };
-            }
-
-            // TODO: Inject from DI
-            var applicator =
-                new WorkspaceEditApplicator(_loggerFactory.CreateLogger<WorkspaceEditApplicator>());
-            var result = await applicator.ApplyAsync(workspaceEdit, cancellationToken);
-
-            if (result.HasErrors)
-            {
-                _logger.LogError("Failed to apply rename changes: {Errors}",
-                    string.Join(", ", result.Errors));
-
-                return new RenameSymbolResult
-                {
-                    Success = false,
-                    Errors = result.Errors,
-                    ChangedFiles = [],
-                    TotalEditsApplied = 0,
-                    TotalFilesChanged = 0,
-                    TotalLinesChanged = 0
-                };
-            }
-
-            _logger.LogInformation(
-                "Successfully renamed symbol: {TotalFilesChanged} files, {TotalEditsApplied} edits, {TotalLinesChanged} lines",
-                result.TotalFilesChanged, result.TotalEditsApplied, result.TotalLinesChanged);
-
-            return new RenameSymbolResult
-            {
-                Success = true,
-                Errors = [],
-                ChangedFiles = result.FilesChanged.Select(r => r.FilePath),
-                TotalFilesChanged = result.TotalFilesChanged,
-                TotalEditsApplied = result.TotalEditsApplied,
-                TotalLinesChanged = result.TotalLinesChanged
+                Message = "Failed to rename symbol",
+                Exception = ex
             };
-        }, cancellationToken);
+        }
     }
 
     public async Task ShutdownAsync(CancellationToken cancellationToken = default)

--- a/src/LspUse.Application/IApplicationService.cs
+++ b/src/LspUse.Application/IApplicationService.cs
@@ -1,4 +1,5 @@
 using LspUse.Application.Models;
+using OneOf;
 
 namespace LspUse.Application;
 
@@ -8,25 +9,39 @@ public interface IApplicationService : IAsyncDisposable
 
     Task WaitForWorkspaceReadyAsync(CancellationToken ct = default);
 
-    Task<FindReferencesResult> FindReferencesAsync(FindReferencesRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<FindReferencesSuccess, ApplicationServiceError>> FindReferencesAsync(
+        FindReferencesRequest request, CancellationToken cancellationToken = default);
 
-    Task<GoToResult> GoToDefinitionAsync(GoToRequest request, CancellationToken cancellationToken = default);
-    Task<GoToResult> GoToTypeDefinitionAsync(GoToRequest request, CancellationToken cancellationToken = default);
-    Task<GoToResult> GoToImplementationAsync(GoToRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<GoToSuccess, ApplicationServiceError>> GoToDefinitionAsync(GoToRequest request,
+        CancellationToken cancellationToken = default);
 
-    Task<CompletionResult> CompletionAsync(CompletionRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<GoToSuccess, ApplicationServiceError>> GoToTypeDefinitionAsync(GoToRequest request,
+        CancellationToken cancellationToken = default);
 
-    Task<HoverResult> HoverAsync(HoverRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<GoToSuccess, ApplicationServiceError>> GoToImplementationAsync(GoToRequest request,
+        CancellationToken cancellationToken = default);
 
-    Task<SearchSymbolResponse> SearchSymbolAsync(SearchSymbolRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<CompletionSuccess, ApplicationServiceError>> CompletionAsync(
+        CompletionRequest request, CancellationToken cancellationToken = default);
 
-    Task<WindowLog> GetWindowLogMessagesAsync(WindowLogRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<HoverSuccess, ApplicationServiceError>> HoverAsync(HoverRequest request,
+        CancellationToken cancellationToken = default);
 
-    Task<GetSymbolsResult> GetDocumentSymbolsAsync(GetSymbolsRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<SearchSymbolSuccess, ApplicationServiceError>> SearchSymbolAsync(
+        SearchSymbolRequest request, CancellationToken cancellationToken = default);
 
-    Task<IEnumerable<DocumentDiagnostic>> GetDocumentDiagnosticsAsync(DocumentDiagnosticsRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<WindowLog, ApplicationServiceError>> GetWindowLogMessagesAsync(
+        WindowLogRequest request, CancellationToken cancellationToken = default);
 
-    Task<RenameSymbolResult> RenameSymbolAsync(RenameSymbolRequest request, CancellationToken cancellationToken = default);
+    Task<OneOf<GetSymbolsSuccess, ApplicationServiceError>> GetDocumentSymbolsAsync(
+        GetSymbolsRequest request, CancellationToken cancellationToken = default);
+
+    Task<OneOf<IEnumerable<DocumentDiagnostic>, ApplicationServiceError>>
+        GetDocumentDiagnosticsAsync(DocumentDiagnosticsRequest request,
+            CancellationToken cancellationToken = default);
+
+    Task<OneOf<RenameSymbolSuccess, ApplicationServiceError>> RenameSymbolAsync(
+        RenameSymbolRequest request, CancellationToken cancellationToken = default);
 
     Task ShutdownAsync(CancellationToken cancellationToken = default);
 }

--- a/src/LspUse.Application/LspUse.Application.csproj
+++ b/src/LspUse.Application/LspUse.Application.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="OneOf" Version="3.0.271" />
   </ItemGroup>
 
 </Project>

--- a/src/LspUse.Application/Models/ApplicationServiceError.cs
+++ b/src/LspUse.Application/Models/ApplicationServiceError.cs
@@ -1,0 +1,8 @@
+namespace LspUse.Application.Models;
+
+public record ApplicationServiceError
+{
+    public required string Message { get; init; }
+    public ErrorCode ErrorCode { get; init; } = ErrorCode.Unknown;
+    public Exception? Exception { get; init; }
+}

--- a/src/LspUse.Application/Models/Completion.cs
+++ b/src/LspUse.Application/Models/Completion.cs
@@ -8,7 +8,7 @@ public record CompletionRequest
     public required EditorPosition Position { get; init; }
 }
 
-public record CompletionResult
+public record CompletionSuccess
 {
     // TODO: Refactor this as is coming from the client layer
     public required IEnumerable<CompletionItem> Items { get; init; }

--- a/src/LspUse.Application/Models/ErrorCode.cs
+++ b/src/LspUse.Application/Models/ErrorCode.cs
@@ -1,0 +1,6 @@
+namespace LspUse.Application.Models;
+
+public enum ErrorCode
+{
+    Unknown = 0
+}

--- a/src/LspUse.Application/Models/FindReferences.cs
+++ b/src/LspUse.Application/Models/FindReferences.cs
@@ -7,7 +7,7 @@ public record FindReferencesRequest
     public bool IncludeDeclaration { get; init; } = true;
 }
 
-public record FindReferencesResult
+public record FindReferencesSuccess
 {
     public required IEnumerable<SymbolLocation> Value { get; init; }
 }

--- a/src/LspUse.Application/Models/GetSymbols.cs
+++ b/src/LspUse.Application/Models/GetSymbols.cs
@@ -5,7 +5,7 @@ public record GetSymbolsRequest
     public required string FilePath { get; init; }
 }
 
-public record GetSymbolsResult
+public record GetSymbolsSuccess
 {
     public required IEnumerable<DocumentSymbol> Symbols { get; init; }
 }

--- a/src/LspUse.Application/Models/GoToDefinition.cs
+++ b/src/LspUse.Application/Models/GoToDefinition.cs
@@ -8,7 +8,7 @@ public record GoToRequest
     public required EditorPosition Position { get; init; }
 }
 
-public record GoToResult
+public record GoToSuccess
 {
     public required IEnumerable<SymbolLocation> Locations { get; init; }
 }

--- a/src/LspUse.Application/Models/Hover.cs
+++ b/src/LspUse.Application/Models/Hover.cs
@@ -6,7 +6,7 @@ public record HoverRequest
     public required EditorPosition Position { get; init; }
 }
 
-public record HoverResult
+public record HoverSuccess
 {
     public required string? Value { get; init; }
 }

--- a/src/LspUse.Application/Models/RenameSymbol.cs
+++ b/src/LspUse.Application/Models/RenameSymbol.cs
@@ -9,7 +9,7 @@ public record RenameSymbolRequest
     public required string NewName { get; init; }
 }
 
-public record RenameSymbolResult
+public record RenameSymbolSuccess
 {
     [JsonPropertyName("success")]
     public required bool Success { get; init; }

--- a/src/LspUse.Application/Models/SearchSymbol.cs
+++ b/src/LspUse.Application/Models/SearchSymbol.cs
@@ -5,7 +5,7 @@ public record SearchSymbolRequest
     public required string Query { get; init; }
 }
 
-public record SearchSymbolResponse
+public record SearchSymbolSuccess
 {
     public required IEnumerable<DocumentSymbol> Value { get; init; }
 }

--- a/src/LspUse.McpServer/LspUse.McpServer.csproj
+++ b/src/LspUse.McpServer/LspUse.McpServer.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="OneOf" Version="3.0.271" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LspUse.McpServer/Tools/DocumentDiagnosticsTool.cs
+++ b/src/LspUse.McpServer/Tools/DocumentDiagnosticsTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -28,7 +29,10 @@ public static class DocumentDiagnosticsTool
                 FilePath = file
             }, cancellationToken);
 
-            return result;
+            return result.Match(
+                success => success,
+                error => throw new InvalidOperationException($"Error getting document diagnostics: {error.Message}", error.Exception)
+            );
         }
         catch (Exception ex)
         {

--- a/src/LspUse.McpServer/Tools/Experimental/CompletionTool.cs
+++ b/src/LspUse.McpServer/Tools/Experimental/CompletionTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -25,49 +26,53 @@ public static class CompletionTool
         logger.LogInformation("MCP CompletionTool called for {FilePath} at {Line}:{Character}",
             file, line, character);
 
-        try
+        var result = await service.CompletionAsync(new CompletionRequest
         {
-            var result = await service.CompletionAsync(new CompletionRequest
+            FilePath = file,
+            Position = new EditorPosition
             {
-                FilePath = file,
-                Position = new EditorPosition
-                {
-                    Line = line,
-                    Character = character
-                }
-            }, cancellationToken);
+                Line = line,
+                Character = character
+            }
+        }, cancellationToken);
 
-            logger.LogInformation("MCP CompletionTool returning {Count} completion items",
-                result.Items.Count());
-
-            return new
+        return result.Match(
+            success =>
             {
-                Items = result.Items.Select(item => new
+                logger.LogInformation("MCP CompletionTool returning {Count} completion items",
+                    success.Items.Count());
+
+                return new
                 {
-                    item.Label,
-                    Kind = item.Kind?.ToString(),
-                    KindValue = (int?)item.Kind
-                })
-                    .ToArray(),
-                Metadata = new
-                {
-                    result.IsIncomplete,
-                    ItemCount = result.Items.Count(),
-                    Position = new
+                    Items = success.Items.Select(item => new
                     {
-                        Line = line,
-                        Character = character
-                    },
-                    File = file
+                        item.Label,
+                        Kind = item.Kind?.ToString(),
+                        KindValue = (int?)item.Kind
+                    })
+                        .ToArray(),
+                    Metadata = new
+                    {
+                        success.IsIncomplete,
+                        ItemCount = success.Items.Count(),
+                        Position = new
+                        {
+                            Line = line,
+                            Character = character
+                        },
+                        File = file
+                    }
+                };
+            },
+            error =>
+            {
+                logger.LogError("MCP CompletionTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
+                {
+                    logger.LogError(error.Exception, "Underlying exception for completion error");
                 }
-            };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error in MCP CompletionTool for {FilePath} at {Line}:{Character}",
-                file, line, character);
-
-            throw;
-        }
+                throw new InvalidOperationException($"Completion operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/FindReferencesTool.cs
+++ b/src/LspUse.McpServer/Tools/FindReferencesTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -36,31 +37,33 @@ public static class FindReferencesTool
         logger.LogInformation("MCP FindReferencesTool called for {FilePath} at {Line}:{Character}",
             file, line, character);
 
-        try
+        var result = await service.FindReferencesAsync(new FindReferencesRequest
         {
-            var result = await service.FindReferencesAsync(new FindReferencesRequest
+            FilePath = file,
+            Position = new EditorPosition
             {
-                FilePath = file,
-                Position = new EditorPosition
+                Line = line,
+                Character = character
+            },
+            IncludeDeclaration = true
+        }, cancellationToken);
+
+        return result.Match<IEnumerable<SymbolLocation>>(
+            success =>
+            {
+                logger.LogInformation("MCP FindReferencesTool returning {Count} references",
+                    success.Value.Count());
+                return success.Value;
+            },
+            error =>
+            {
+                logger.LogError("MCP FindReferencesTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
                 {
-                    Line = line,
-                    Character = character
-                },
-                IncludeDeclaration = true
-            }, cancellationToken);
-
-            logger.LogInformation("MCP FindReferencesTool returning {Count} references",
-                result.Value.Count());
-
-            return result.Value;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex,
-                "Error in MCP FindReferencesTool for {FilePath} at {Line}:{Character}", file, line,
-                character);
-
-            throw;
-        }
+                    logger.LogError(error.Exception, "Underlying exception for find references error");
+                }
+                throw new InvalidOperationException($"Find references operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/GetSymbolsTool.cs
+++ b/src/LspUse.McpServer/Tools/GetSymbolsTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -21,20 +22,26 @@ public static class GetSymbolsTool
 
         logger.LogInformation("MCP DocumentSymbolsTool called for {FilePath}", file);
 
-        try
+        var result = await service.GetDocumentSymbolsAsync(new GetSymbolsRequest
         {
-            var result = await service.GetDocumentSymbolsAsync(new GetSymbolsRequest
+            FilePath = file
+        }, cancellationToken);
+
+        return result.Match<IEnumerable<DocumentSymbol>>(
+            success =>
             {
-                FilePath = file
-            }, cancellationToken);
-
-            return result.Symbols.ToList() ?? [];
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error in MCP DocumentSymbolsTool for {FilePath}", file);
-
-            throw;
-        }
+                logger.LogInformation("MCP DocumentSymbolsTool returning {Count} symbols", success.Symbols.Count());
+                return success.Symbols.ToList() ?? [];
+            },
+            error =>
+            {
+                logger.LogError("MCP DocumentSymbolsTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
+                {
+                    logger.LogError(error.Exception, "Underlying exception for document symbols error");
+                }
+                throw new InvalidOperationException($"Document symbols operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/GoToDefinitionTool.cs
+++ b/src/LspUse.McpServer/Tools/GoToDefinitionTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -35,27 +36,31 @@ public static class GoToDefinitionTool
 
         logger.LogInformation("{File} at {Line}:{Character}", file, line, character);
 
-        try
+        var result = await service.GoToDefinitionAsync(new GoToRequest
         {
-            var result = await service.GoToDefinitionAsync(new GoToRequest
+            FilePath = file,
+            Position = new EditorPosition
             {
-                FilePath = file,
-                Position = new EditorPosition
+                Line = line,
+                Character = character
+            }
+        }, cancellationToken);
+
+        return result.Match<IEnumerable<SymbolLocation>>(
+            success =>
+            {
+                logger.LogInformation("MCP GoToDefinitionTool returning {Count} locations", success.Locations.Count());
+                return success.Locations;
+            },
+            error =>
+            {
+                logger.LogError("MCP GoToDefinitionTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
                 {
-                    Line = line,
-                    Character = character
+                    logger.LogError(error.Exception, "Underlying exception for go to definition error");
                 }
-            }, cancellationToken);
-
-            return result.Locations;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex,
-                "Error in MCP GoToDefinitionTool for {FilePath} at {Line}:{Character}", file, line,
-                character);
-
-            throw;
-        }
+                throw new InvalidOperationException($"Go to definition operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/GoToImplementationTool.cs
+++ b/src/LspUse.McpServer/Tools/GoToImplementationTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -35,26 +36,31 @@ public static class GoToImplementationTool
 
         logger.LogInformation("{File} at {Line}:{Character}", file, line, character);
 
-        try
+        var result = await service.GoToImplementationAsync(new GoToRequest
         {
-            var result = await service.GoToImplementationAsync(new GoToRequest
+            FilePath = file,
+            Position = new EditorPosition
             {
-                FilePath = file,
-                Position = new EditorPosition
+                Line = line,
+                Character = character
+            }
+        }, cancellationToken);
+
+        return result.Match<IEnumerable<SymbolLocation>>(
+            success =>
+            {
+                logger.LogInformation("MCP GoToImplementationTool returning {Count} locations", success.Locations.Count());
+                return success.Locations;
+            },
+            error =>
+            {
+                logger.LogError("MCP GoToImplementationTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
                 {
-                    Line = line,
-                    Character = character
+                    logger.LogError(error.Exception, "Underlying exception for go to implementation error");
                 }
-            }, cancellationToken);
-
-            return result.Locations;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error for {FilePath} at {Line}:{Character}", file, line,
-                character);
-
-            throw;
-        }
+                throw new InvalidOperationException($"Go to implementation operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/GoToTypeDefinitionTool.cs
+++ b/src/LspUse.McpServer/Tools/GoToTypeDefinitionTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -35,26 +36,31 @@ public static class GoToTypeDefinitionTool
 
         logger.LogInformation("{File} at {Line}:{Character}", file, line, character);
 
-        try
+        var result = await service.GoToTypeDefinitionAsync(new GoToRequest
         {
-            var result = await service.GoToTypeDefinitionAsync(new GoToRequest
+            FilePath = file,
+            Position = new EditorPosition
             {
-                FilePath = file,
-                Position = new EditorPosition
+                Line = line,
+                Character = character
+            }
+        }, cancellationToken);
+
+        return result.Match<IEnumerable<SymbolLocation>>(
+            success =>
+            {
+                logger.LogInformation("MCP GoToTypeDefinitionTool returning {Count} locations", success.Locations.Count());
+                return success.Locations;
+            },
+            error =>
+            {
+                logger.LogError("MCP GoToTypeDefinitionTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
                 {
-                    Line = line,
-                    Character = character
+                    logger.LogError(error.Exception, "Underlying exception for go to type definition error");
                 }
-            }, cancellationToken);
-
-            return result.Locations;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error for {FilePath} at {Line}:{Character}", file, line,
-                character);
-
-            throw;
-        }
+                throw new InvalidOperationException($"Go to type definition operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/HoverTool.cs
+++ b/src/LspUse.McpServer/Tools/HoverTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -25,29 +26,32 @@ public static class HoverTool
         logger.LogInformation("MCP HoverTool called for {FilePath} at {Line}:{Character}", file,
             line, character);
 
-        try
+        var result = await service.HoverAsync(new HoverRequest
         {
-            var result = await service.HoverAsync(new HoverRequest
+            FilePath = file,
+            Position = new EditorPosition
             {
-                FilePath = file,
-                Position = new EditorPosition
+                Line = line,
+                Character = character
+            }
+        }, cancellationToken);
+
+        return result.Match<object?>(
+            success =>
+            {
+                logger.LogInformation("MCP HoverTool returning hover content: {HasContent}",
+                    success.Value != null);
+                return success.Value;
+            },
+            error =>
+            {
+                logger.LogError("MCP HoverTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
                 {
-                    Line = line,
-                    Character = character
+                    logger.LogError(error.Exception, "Underlying exception for hover error");
                 }
-            }, cancellationToken);
-
-            logger.LogInformation("MCP HoverTool returning hover content: {HasContent}",
-                result.Value != null);
-
-            return result.Value;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error in MCP HoverTool for {FilePath} at {Line}:{Character}", file,
-                line, character);
-
-            throw;
-        }
+                throw new InvalidOperationException($"Hover operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/RenameSymbolTool.cs
+++ b/src/LspUse.McpServer/Tools/RenameSymbolTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -22,7 +23,7 @@ public static class RenameSymbolTool
 
     [McpServerTool(Name = ToolName, Title = ToolTitle, UseStructuredContent = true)]
     [Description(ToolDescription)]
-    public static async Task<RenameSymbolResult> RenameSymbolAsync(
+    public static async Task<RenameSymbolSuccess> RenameSymbolAsync(
         IApplicationService applicationService, ILoggerFactory loggerFactory,
         [Description(ToolArgDescFilePath)] string filePath,
         [Description(ToolArgDescLine)] uint line,
@@ -35,26 +36,35 @@ public static class RenameSymbolTool
         logger.LogInformation("Renaming symbol at {FilePath}:{Line}:{Character} to '{NewName}'",
             filePath, line, character, newName);
 
-        try
+        var request = new RenameSymbolRequest
         {
-            var request = new RenameSymbolRequest
+            FilePath = filePath,
+            Position = new EditorPosition
             {
-                FilePath = filePath,
-                Position = new EditorPosition
+                Line = line,
+                Character = character
+            },
+            NewName = newName
+        };
+
+        var result = await applicationService.RenameSymbolAsync(request, cancellationToken);
+
+        return result.Match(
+            success =>
+            {
+                logger.LogInformation("Symbol rename completed successfully. Changed {FileCount} files with {TotalEdits} edits", 
+                    success.ChangedFiles.Count(), success.TotalEditsApplied);
+                return success;
+            },
+            error =>
+            {
+                logger.LogError("Symbol rename error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
                 {
-                    Line = line,
-                    Character = character
-                },
-                NewName = newName
-            };
-
-            return await applicationService.RenameSymbolAsync(request, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error during symbol rename operation");
-
-            throw;
-        }
+                    logger.LogError(error.Exception, "Underlying exception for symbol rename error");
+                }
+                throw new InvalidOperationException($"Symbol rename operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/SearchSymbolTool.cs
+++ b/src/LspUse.McpServer/Tools/SearchSymbolTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -28,24 +29,27 @@ public static class SearchSymbolTool
 
         logger.LogInformation("MCP SearchSymbolsTool called with query: {Query}", query);
 
-        try
+        var result = await service.SearchSymbolAsync(new SearchSymbolRequest
         {
-            var result = await service.SearchSymbolAsync(new SearchSymbolRequest
+            Query = query
+        }, cancellationToken);
+
+        return result.Match<IEnumerable<DocumentSymbol>>(
+            success =>
             {
-                Query = query
-            }, cancellationToken);
-
-            var symbolList = result.Value.ToList();
-            logger.LogInformation("MCP SearchSymbolsTool returning {Count} symbols",
-                symbolList.Count);
-
-            return result.Value;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Error in MCP SearchSymbolsTool for query: {Query}", query);
-
-            throw;
-        }
+                var symbolList = success.Value.ToList();
+                logger.LogInformation("MCP SearchSymbolsTool returning {Count} symbols", symbolList.Count);
+                return success.Value;
+            },
+            error =>
+            {
+                logger.LogError("MCP SearchSymbolsTool error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
+                {
+                    logger.LogError(error.Exception, "Underlying exception for search symbols error");
+                }
+                throw new InvalidOperationException($"Search symbols operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }

--- a/src/LspUse.McpServer/Tools/WindowLogMessagesTool.cs
+++ b/src/LspUse.McpServer/Tools/WindowLogMessagesTool.cs
@@ -3,6 +3,7 @@ using LspUse.Application;
 using LspUse.Application.Models;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using OneOf;
 
 namespace LspUse.McpServer.Tools;
 
@@ -20,30 +21,35 @@ public static class WindowLogMessagesTool
 
         logger.LogInformation("[WindowLogMessagesTool] Getting window log messages");
 
-        try
-        {
-            var request = new WindowLogRequest();
-            var result = await service.GetWindowLogMessagesAsync(request, cancellationToken);
+        var request = new WindowLogRequest();
+        var result = await service.GetWindowLogMessagesAsync(request, cancellationToken);
 
-            logger.LogInformation("[WindowLogMessagesTool] Retrieved {Count} log messages",
-                result.LogMessages.Count());
-
-            return new
+        return result.Match(
+            success =>
             {
-                logMessages = result.LogMessages.Select(msg => new
-                {
-                    message = msg.Message,
-                    messageType = msg.MessageType.ToString()
-                })
-                    .ToArray(),
-                totalCount = result.LogMessages.Count()
-            };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "[WindowLogMessagesTool] Error getting window log messages");
+                logger.LogInformation("[WindowLogMessagesTool] Retrieved {Count} log messages",
+                    success.LogMessages.Count());
 
-            throw;
-        }
+                return new
+                {
+                    logMessages = success.LogMessages.Select(msg => new
+                    {
+                        message = msg.Message,
+                        messageType = msg.MessageType.ToString()
+                    })
+                        .ToArray(),
+                    totalCount = success.LogMessages.Count()
+                };
+            },
+            error =>
+            {
+                logger.LogError("[WindowLogMessagesTool] Error: {Message} ({ErrorCode})", error.Message, error.ErrorCode);
+                if (error.Exception != null)
+                {
+                    logger.LogError(error.Exception, "Underlying exception for window log messages error");
+                }
+                throw new InvalidOperationException($"Window log messages operation failed: {error.Message}", error.Exception);
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the **OneOf<>** pattern for error handling across the ApplicationService layer, improving type safety and making error handling more explicit and predictable.

### Key Changes

🔧 **Core Implementation**
- Added OneOf NuGet package (v3.0.271) to Application and McpServer projects
- Introduced `ApplicationServiceError` record with simplified error structure
- Added `ErrorCode` enum for structured error categorization
- Updated `IApplicationService` interface with OneOf return types

🏗️ **Architecture Improvements**
- All result-returning methods now return `OneOf<SuccessType, ApplicationServiceError>`
- Task-only methods (InitialiseAsync, WaitForWorkspaceReadyAsync, ShutdownAsync) remain unchanged
- Comprehensive try-catch blocks with structured error handling

📝 **Model Refactoring**
- Renamed result types for semantic clarity:
  - `FindReferencesResult` → `FindReferencesSuccess`
  - `GoToResult` → `GoToSuccess`
  - `CompletionResult` → `CompletionSuccess`
  - `SearchSymbolResponse` → `SearchSymbolSuccess`
  - `HoverResult` → `HoverSuccess`
  - `GetSymbolsResult` → `GetSymbolsSuccess`
  - `RenameSymbolResult` → `RenameSymbolSuccess`

🛠️ **MCP Tools Enhancement**
- Updated all 11 MCP tools to use OneOf.Match() pattern
- Maintained backward compatibility by throwing exceptions on error cases
- Added comprehensive logging for success and error scenarios

📚 **Documentation**
- Enhanced Git workflow documentation in CLAUDE.md
- Added feature branch development guidelines
- Included PR creation and commit message standards

### Technical Benefits

✅ **Type Safety**: Compile-time guarantees that error cases are handled
✅ **Explicit Error Handling**: No more silent failures or unclear error states
✅ **Structured Logging**: Consistent error reporting with ErrorCode enum
✅ **Maintainability**: Clear separation between success and error paths
✅ **Testing**: More predictable error scenarios for unit testing

### Error Structure

```csharp
public record ApplicationServiceError
{
    public required string Message { get; init; }           // User-friendly message
    public ErrorCode ErrorCode { get; init; } = ErrorCode.Unknown;  // Structured error code
    public Exception? Exception { get; init; }             // Original exception for logging
}
```

### Usage Pattern

```csharp
// ApplicationService method
var result = await applicationService.FindReferencesAsync(request);
return result.Match(
    success => success.Value,
    error => throw new InvalidOperationException($"Operation failed: {error.Message}", error.Exception)
);
```

### Files Changed

- **Core Models**: ApplicationServiceError.cs, ErrorCode.cs
- **Interfaces**: IApplicationService.cs updated with OneOf signatures
- **Implementation**: ApplicationService.cs with comprehensive error handling
- **MCP Tools**: All 11 tools updated with OneOf.Match() pattern
- **Project Files**: NuGet package references added
- **Documentation**: Enhanced Git workflow in CLAUDE.md

### Testing

- ✅ All builds pass without compilation errors
- ✅ Maintains backward compatibility for MCP tool consumers
- ✅ Comprehensive error logging and handling
- ✅ LSP rename tool used for 100% accuracy in refactoring

### Migration Impact

This is a **breaking change** for internal ApplicationService consumers but **maintains compatibility** for MCP tool users. The OneOf pattern provides:

1. **Compile-time safety** - impossible to ignore error cases
2. **Clear intent** - explicit success/error handling
3. **Better debugging** - structured error information
4. **Future extensibility** - easy to add new error types

🚀 **Generated with [Claude Code](https://claude.ai/code)**

**Co-Authored-By: Claude <noreply@anthropic.com>**